### PR TITLE
Fix request traceparent id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+ 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+ 
+## [0.9.1] - 2023-03-16
+ 
+A minor release to make the traceparent header compliant with the W3C version 00 standard.
+ 
+### Added
+ 
+### Changed
+ 
+### Fixed
+
+Fixes issue [#1](https://github.com/newrelic-experimental/apigee-distributed-tracing/issues/1).
+
+Increase length of parent-id component of the W3C traceparent header to 16 characters, to comply with the [W3C standard](https://www.w3.org/TR/trace-context/#parent-id) for version 00.
+
+Comment out reference to pub/sub message policy that is no longer present in the repo. This allows the sample code to work with minimal configuration.
+

--- a/src/main/apigee/apiproxies/W3C-Trace-Context/apiproxy/proxies/default.xml
+++ b/src/main/apigee/apiproxies/W3C-Trace-Context/apiproxy/proxies/default.xml
@@ -4,9 +4,9 @@
 			<Step>
 				<Name>Trace-Context-Request</Name>
 			</Step>
-			<Step>
+			<!-- <Step>
 				<Name>Add-Trace-Context-To-Pub-Sub-Message</Name>
-			</Step>
+			</Step> -->
 		</Request>
 	</PreFlow>
 	<PostFlow name="PostFlow">

--- a/src/main/apigee/apiproxies/W3C-Trace-Context/apiproxy/resources/jsc/Trace-Context-Request.js
+++ b/src/main/apigee/apiproxies/W3C-Trace-Context/apiproxy/resources/jsc/Trace-Context-Request.js
@@ -155,7 +155,7 @@ else {
                     // Update parent-id: The value of property parent-id MUST be set to a value representing the ID of the current operation.
                     // Update sampled: The value of sampled reflects the caller's recording behavior. The value of the sampled flag of trace-flags MAY be set to 1 if the trace data is likely to be recorded or to 0 otherwise. Setting the flag is no guarantee that the trace will be recorded but increases the likeliness of end-to-end recorded traces.
                     requestParentID = parentID;
-                    parentID = generateValidID(8);
+                    parentID = generateValidID(16);
                     traceFlags = generateSampled();
                 } else {
                     logMsg(logPrefix + 'Error: invalid traceFlags: ' + traceFlags);

--- a/src/main/apigee/apiproxies/W3C-Trace-Context/apiproxy/targets/default.xml
+++ b/src/main/apigee/apiproxies/W3C-Trace-Context/apiproxy/targets/default.xml
@@ -4,9 +4,9 @@
 			<Step>
 				<Name>Target-Trace-Context-Request</Name>
 			</Step>
-			<Step>
+			<!-- <Step>
 				<Name>Add-Trace-Context-To-Pub-Sub-Message</Name>
-			</Step>
+			</Step> -->
 		</Request>
 	</PreFlow>
 	<PostFlow name="PostFlow">


### PR DESCRIPTION
Fixes issue #1.

Increase length of parent id component of the W3C traceparent header to 16 characters.

Comment out reference to pub/sub message policy that is no longer present in the repo on main/latest.